### PR TITLE
Fixed telescope saving views on each load

### DIFF
--- a/resources/config/telescope.php
+++ b/resources/config/telescope.php
@@ -70,12 +70,12 @@ return [
     */
 
     'watchers' => [
-        // 'views'      => [
-        //     'enabled' => env('TELESCOPE_VIEW_WATCHER', true),
-        //     'view'    => 'anomaly.module.system::admin/views',
-        //     'table'   => \Anomaly\SystemModule\Telescope\Table\ViewTableBuilder::class,
-        //     'key'     => 'telescope.watchers.Laravel\Telescope\Watchers\ViewWatcher.enabled',
-        // ],
+        'views'      => [
+            'enabled' => env('TELESCOPE_VIEW_WATCHER', true),
+            'view'    => 'anomaly.module.system::admin/views',
+            'table'   => \Anomaly\SystemModule\Telescope\Table\ViewTableBuilder::class,
+            'key'     => 'telescope.watchers.Laravel\Telescope\Watchers\ViewWatcher.enabled',
+        ],
         'requests'      => [
             'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
             'view'    => 'anomaly.module.system::admin/requests',


### PR DESCRIPTION
When this is commented out telescope is saving views on each page load. The database is being filled quickly. I didn't find a reason of it being commented out so it might've been commented out by mistake.